### PR TITLE
Remove length and width properties from tiles

### DIFF
--- a/Master-Game/World/BaseTile.cs
+++ b/Master-Game/World/BaseTile.cs
@@ -5,18 +5,14 @@
         public TileType Type { get; }
         public bool Passable { get; }
         public bool Occupied { get; set; }
-        public int Length { get; }
-        public int Width { get; }
         public int Elevation { get; }
         public float Damage { get; }
 
-        public BaseTile(TileType type, bool passable, int length, int width, float damage)
+        public BaseTile(TileType type, bool passable, float damage)
         {
             Type = type;
             Passable = passable;
             Occupied = false;
-            Length = length;
-            Width = width;
             Elevation = 0;
             Damage = damage;
         }

--- a/Master-Game/World/GrassTile.cs
+++ b/Master-Game/World/GrassTile.cs
@@ -2,8 +2,8 @@
 {
     public class GrassTile : BaseTile
     {
-        public GrassTile(int length, int width) 
-            : base(TileType.Grass, true, length, width, 0.0f)
+        public GrassTile() 
+            : base(TileType.Grass, true, 0.0f)
         {
         }
     }

--- a/Master-Game/World/LavaTile.cs
+++ b/Master-Game/World/LavaTile.cs
@@ -2,8 +2,8 @@
 {
     public class LavaTile : BaseTile
     {
-        public LavaTile(int length, int width)
-            : base (TileType.Lava, true, length, width, 10.0f)
+        public LavaTile()
+            : base (TileType.Lava, true, 10.0f)
         {
         }
     }

--- a/Master-Game/World/Map.cs
+++ b/Master-Game/World/Map.cs
@@ -10,10 +10,10 @@ namespace MasterGame.World
         {
             CurrentMap = new BaseTile [4,4]
             {
-                { new GrassTile(1, 1), new LavaTile(1, 1), new GrassTile(1, 1), new GrassTile(1, 1) },
-                { new GrassTile(1, 1), new LavaTile(1, 1), new WaterTile(1, 1), new GrassTile(1, 1) },
-                { new GrassTile(1, 1), new GrassTile(1, 1), new WaterTile(1, 1), new GrassTile(1, 1) },
-                { new GrassTile(1, 1), new GrassTile(1, 1), new GrassTile(1, 1), new GrassTile(1, 1) }   
+                { new GrassTile(), new LavaTile(), new GrassTile(), new GrassTile() },
+                { new GrassTile(), new LavaTile(), new WaterTile(), new GrassTile() },
+                { new GrassTile(), new GrassTile(), new WaterTile(), new GrassTile() },
+                { new GrassTile(), new GrassTile(), new GrassTile(), new GrassTile() }   
             };
         }
 

--- a/Master-Game/World/WaterTile.cs
+++ b/Master-Game/World/WaterTile.cs
@@ -8,8 +8,8 @@ namespace MasterGame.World
 {
     class WaterTile : BaseTile
     {
-        public WaterTile(int length, int width)
-            :base(TileType.Water, true, length, width, -5.0f)
+        public WaterTile()
+            :base(TileType.Water, true, -5.0f)
         {
 
         }


### PR DESCRIPTION
Removed length and width properties from tiles to fix issue #19 as we have determined we are assuming each tile is 1x1.