### PR TITLE
Add max health for base entities

### DIFF
--- a/Master-Game/Entities/BaseEntity.cs
+++ b/Master-Game/Entities/BaseEntity.cs
@@ -7,18 +7,20 @@ namespace MasterGame.Entities
         public EntityType Type { get; }
         public string Name { get; }
         public float HealthPoints { get; set; }
+        public float MaxHealthPoints { get; set; }
         public bool CanCollide { get; }
         public bool CanMove { get; }
         public bool CanTakeDamage { get; }
         public bool PlayerControlled { get; }
         public Point Position;
 
-        public BaseEntity(EntityType type, string name, float healthPoints, 
+        public BaseEntity(EntityType type, string name, float healthPoints, float maxHealthPoints,
                           bool canCollide, bool canMove, bool canTakeDamage, bool isPlayerControlled)
         {
             Type = type;
             Name = name;
             HealthPoints = healthPoints;
+            MaxHealthPoints = maxHealthPoints;
             CanCollide = canCollide;
             CanMove = canMove;
             CanTakeDamage = canTakeDamage;
@@ -30,6 +32,16 @@ namespace MasterGame.Entities
         public bool isAlive()
         {
             return HealthPoints > 0.0f;
+        }
+
+        public void AddDamage(float appliedDamage)
+        {
+            HealthPoints -= appliedDamage;
+
+            if(HealthPoints > MaxHealthPoints)
+            {
+                HealthPoints = MaxHealthPoints;
+            }
         }
     }
 }

--- a/Master-Game/Entities/HumanEntity.cs
+++ b/Master-Game/Entities/HumanEntity.cs
@@ -3,8 +3,8 @@ namespace MasterGame.Entities
 {
     public class HumanEntity : BaseEntity
     {
-        public HumanEntity(string name, float healthPoints)
-            : base (EntityType.Human, name, healthPoints, true, true, true, false)
+        public HumanEntity(string name, float healthPoints, float maxHealthPoints)
+            : base (EntityType.Human, name, healthPoints, maxHealthPoints, true, true, true, false)
         {
         }
     }

--- a/Master-Game/Entities/PlayerEntity.cs
+++ b/Master-Game/Entities/PlayerEntity.cs
@@ -5,8 +5,8 @@ namespace MasterGame.Entities
 {
     public class PlayerEntity : BaseEntity
     {
-        public PlayerEntity(string name, float healthPoints)
-           : base(EntityType.Player, name, healthPoints, true, true, true, true)
+        public PlayerEntity(string name, float healthPoints, float maxHealthPoints)
+           : base(EntityType.Player, name, healthPoints, maxHealthPoints, true, true, true, true)
         {
         }
 

--- a/Master-Game/Managers/EntityManager.cs
+++ b/Master-Game/Managers/EntityManager.cs
@@ -9,7 +9,7 @@ namespace MasterGame.Manager
 
         public void Initialize()
         {
-            EntityList.Add(new PlayerEntity("PlayerOne", 100.0f));
+            EntityList.Add(new PlayerEntity("PlayerOne", 100.0f, 100.0f));
         }
 
         public BaseEntity GetPlayer()

--- a/Master-Game/Managers/GameManager.cs
+++ b/Master-Game/Managers/GameManager.cs
@@ -119,7 +119,7 @@ namespace MasterGame.Manager
             BaseTile tile = MasterWorldManager.TileAt(player.Position);
             if (tile != null)
             {
-                player.HealthPoints -= tile.Damage;
+                player.AddDamage(tile.Damage);
             }
         }
 

--- a/Master-Game/Managers/RenderingManager.cs
+++ b/Master-Game/Managers/RenderingManager.cs
@@ -75,7 +75,7 @@ namespace MasterGame.Manager
         {
             if (player.isAlive())
             {
-                Console.WriteLine("HP: " + player.HealthPoints);
+                Console.WriteLine("HP: " + player.HealthPoints + " / " + player.MaxHealthPoints);
                 Console.WriteLine("Where to next?");
             }
             else


### PR DESCRIPTION
#17 

In this PR I added a max health attribute for the base entities. I'm ready for your changes!
---
I added max health for the base entities. For example, if the max HP of a player is 100, the player's health should be no more than 100. 

I also added a method that applies damage to a base entity. I added this to the base entity class. I added it to that base entity because I thought that every base entity will have a max health. I think that we should use a method, as opposed to changing the attribute directly because this will allow us to add check when change the health points.

Need to update the lines of code that used called the base entity class