### PR TITLE
Add collectible class and example types

### DIFF
--- a/Master-Game/World/BaseCollectible.cs
+++ b/Master-Game/World/BaseCollectible.cs
@@ -1,0 +1,24 @@
+﻿namespace MasterGame.World
+{
+    public class BaseCollectible
+    {
+        public TileType Type { get; }
+        public bool Passable { get; }
+        public bool Occupied { get; set; }
+        public int Elevation { get; }
+        public float Damage { get; }
+        public int X { get; set; }
+        public int Y { get; set; }
+
+        public BaseCollectible(CollectibleType type, bool passable, float damage)
+        {
+            Type = type;
+            Passable = passable;
+            Occupied = false;
+            Elevation = 0;
+            Damage = damage;
+            X = -1;
+            Y = -1;
+        }
+    }
+}

--- a/Master-Game/World/CollectibleType.cs
+++ b/Master-Game/World/CollectibleType.cs
@@ -1,0 +1,11 @@
+﻿namespace MasterGame.World
+{
+    public enum CollectibleType : byte
+    {
+        Unknown,
+        Bow,
+        Pickaxe,
+        Staff,
+        Sword,
+    }
+}


### PR DESCRIPTION
In response to Issue #12 regarding collectibles:

- Add 2 "collectible" classes to the World folder
- These classes create collectibles similar to how the "Tile" class creates tiles
- "BaseCollectible" class defines the features used for any collectibles created
- "CollectibleType" lists each kind of collectible (to be determined)